### PR TITLE
Fixed MemoryPacket name

### DIFF
--- a/src/sinuca3.hpp
+++ b/src/sinuca3.hpp
@@ -58,7 +58,7 @@ struct InstructionPacket {};
 /**
  * @brief Used by SimpleMemory.
  */
-struct MessagePacket {};
+struct MemoryPacket {};
 
 }  // namespace sinuca
 

--- a/src/std_components/simple_memory.hpp
+++ b/src/std_components/simple_memory.hpp
@@ -32,11 +32,11 @@
  * every request. I.e., it's the perfect memory: big and works at the light
  * speed!
  */
-class SimpleMemory : public sinuca::Component<sinuca::MessagePacket> {
+class SimpleMemory : public sinuca::Component<sinuca::MemoryPacket> {
   public:
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter,
-                           sinuca::config::ConfigValue value);
+                                   sinuca::config::ConfigValue value);
     virtual void Clock();
     ~SimpleMemory();
 };


### PR DESCRIPTION
For some reason MemoryPacket was called MessagePacket.