### PR TITLE
Fix typo in debug print statement

### DIFF
--- a/src/utils/logging.hpp
+++ b/src/utils/logging.hpp
@@ -44,7 +44,7 @@
 #ifndef NDEBUG
 #define SINUCA3_DEBUG_PRINTF(...) \
     {                             \
-        printf("[DEBUG]");        \
+        printf("[DEBUG] ");       \
         printf(__VA_ARGS__);      \
     }
 #else


### PR DESCRIPTION
Corrected a typo in the SINUCA3_DEBUG_PRINTF macro to include a space after the "[DEBUG]" label.