### PR TITLE
Fixed compilation by renaming the include for buffer.hpp

### DIFF
--- a/src/trace_reader/sinuca3_trace_reader.cpp
+++ b/src/trace_reader/sinuca3_trace_reader.cpp
@@ -27,8 +27,8 @@
 
 #include "../../trace_generator/sinuca3_pintool.hpp"
 #include "../utils/logging.hpp"
+#include "buffer.hpp"
 #include "trace_reader.hpp"
-#include "buffer.h"
 
 extern "C" {
 #include <sys/mman.h>


### PR DESCRIPTION
The rename was merged without checking for the compilation.