### PR TITLE
Changed method GetConnections to GetNumberOfConnections

### DIFF
--- a/src/engine/linkable.cpp
+++ b/src/engine/linkable.cpp
@@ -120,10 +120,9 @@ void sinuca::engine::Linkable::AddConnection(Connection* newConnection) {
         this->numberOfConnections = connectionsSize;
 };
 
-std::vector<sinuca::engine::Connection*>
-sinuca::engine::Linkable::GetConnections() const {
-    return this->connections;
-};
+long sinuca::engine::Linkable::GetNumberOfConnections() {
+    return this->numberOfConnections;
+}
 
 void sinuca::engine::Linkable::LinkableFlush() {
     for (unsigned int i = 0; i < this->connections.size(); ++i)

--- a/src/engine/linkable.hpp
+++ b/src/engine/linkable.hpp
@@ -212,7 +212,8 @@ class Linkable {
     /**
      * @brief Self-explanatory
      */
-    std::vector<Connection*> GetConnections() const;
+    long GetNumberOfConnections();
+
     /**
      * @brief Don't call this method.
      * @details The engine calls this method after each clock cycle to swap the

--- a/src/std_components/engine_debug_component.cpp
+++ b/src/std_components/engine_debug_component.cpp
@@ -140,9 +140,7 @@ void EngineDebugComponent::Clock() {
             }
         }
     } else {
-        std::vector<sinuca::engine::Connection*> connections =
-            this->GetConnections();
-        for (unsigned int i = 0; i < connections.size(); ++i) {
+        for (long i = 0; i < this->GetNumberOfConnections(); ++i) {
             if (this->ReceiveRequestFromConnection(i, &messageOutput)) {
                 SINUCA3_DEBUG_PRINTF("%p: Received message (%p)\n", this,
                                      messageOutput.staticInfo);


### PR DESCRIPTION
The components don't need access to the inner Connection struct, they only need
to know the number of connections they have. This swaps the method
GetConnections with GetNumberOfConnections that's simpler and satisfies all uses.