### PR TITLE
Added testing infrastructure

### DIFF
--- a/src/engine/linkable.cpp
+++ b/src/engine/linkable.cpp
@@ -113,11 +113,8 @@ void sinuca::engine::Linkable::DeallocateConnectionsBuffer() {
 }
 
 void sinuca::engine::Linkable::AddConnection(Connection* newConnection) {
-    int connectionsSize = this->connections.size();
     this->connections.push_back(newConnection);
-
-    if (connectionsSize > this->numberOfConnections)
-        this->numberOfConnections = connectionsSize;
+    this->numberOfConnections += 1;
 }
 
 long sinuca::engine::Linkable::GetNumberOfConnections() {

--- a/src/std_components/ras.hpp
+++ b/src/std_components/ras.hpp
@@ -52,4 +52,8 @@ class Ras : public sinuca::Component<sinuca::PredictorPacket> {
     virtual ~Ras();
 };
 
+#ifndef NDEBUG
+int TestRas();
+#endif
+
 #endif  // SINUCA3_RAS_HPP_

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -1,0 +1,48 @@
+#ifndef NDEBUG
+
+//
+// Copyright (C) 2025  HiPES - Universidade Federal do Paraná
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+/**
+ * @file tests.cpp
+ * @details Defines the tests the simulator supports.
+ */
+
+#include "tests.hpp"
+
+#include <cstring>
+
+#include "std_components/ras.hpp"
+#include "utils/logging.hpp"
+
+int TestExample() {
+    SINUCA3_LOG_PRINTF("Hello, World!\n");
+
+    return 0;
+}
+
+/**
+ * @brief Runs a test by name.
+ */
+int Test(const char* test) {
+    TEST(TestExample);
+    TEST(TestRas);
+
+    return -1;
+}
+
+#endif

--- a/src/tests.hpp
+++ b/src/tests.hpp
@@ -1,0 +1,32 @@
+#ifndef SINUCA3_TESTS_HPP_
+#define SINUCA3_TESTS_HPP_
+
+//
+// Copyright (C) 2025  HiPES - Universidade Federal do Paraná
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+/**
+ * @file tests.hpp
+ * @details Infrastructure to the tests the simulator supports.
+ */
+
+int TestExample();
+int Test(const char* test);
+
+#define TEST(func) \
+    if (!strcmp(test, #func)) return func()
+
+#endif  // SINUCA3_TESTS_HPP_


### PR DESCRIPTION
This adds a testing infrastructure by adding a command line option to run tests
in debug mode.

Tests are declared in the tests.cpp file in a very similar manner to the way
components are declared.

Tests should be inside `#ifndef NDEBUG` clauses so they are not compiled in
release mode.

I wrote an example test and a test for the Ras component. It was actually
successful as I found actual bugs in Linkable and the Ras itself. The're fixed
in this branch.
