### PR TITLE
Inverted fetching API so the engine is a component

### DIFF
--- a/config_files/engine_debug.yaml
+++ b/config_files/engine_debug.yaml
@@ -11,5 +11,6 @@ otherComponent: &otherComponent
   parameter2: 69
   parameter3: true
 
-cores:
-  - class: EngineDebugComponent
+instantiate:
+  class: EngineDebugComponent
+  fetch: *ENGINE

--- a/config_files/simple_test.yaml
+++ b/config_files/simple_test.yaml
@@ -1,9 +1,7 @@
-core:
+instantiate:
   class: SimpleCore
+  fetching: *ENGINE
   dataMemory:
     class: SimpleMemory
   instructionMemory:
     class: SimpleMemory
-
-cores:
-  - core

--- a/src/engine/default_packets.hpp
+++ b/src/engine/default_packets.hpp
@@ -23,7 +23,6 @@
  * @brief Standard message types.
  */
 
-#include <cstdlib>
 #include <cstring>
 
 namespace sinuca {

--- a/src/std_components/cores/simple_core.hpp
+++ b/src/std_components/cores/simple_core.hpp
@@ -27,23 +27,26 @@
 #include "../../sinuca3.hpp"
 
 /**
- * @details SimpleCore executes everything in a single cycle. You can optionally
- * set an instructionMemory and a dataMemory pointers to components that extend
- * Component<MemoryPacket>.
+ * @details SimpleCore fetches an instruction from the parameter `fetching` and
+ * optionally queries two memories (without caring with the result at all) with
+ * the instruction.
  */
 class SimpleCore : public sinuca::Component<sinuca::InstructionPacket> {
   private:
     sinuca::Component<sinuca::MemoryPacket>* instructionMemory;
     sinuca::Component<sinuca::MemoryPacket>* dataMemory;
+    sinuca::Component<sinuca::InstructionPacket>* fetching;
 
+    unsigned long numFetchedInstructions;
     int instructionConnectionID;
     int dataConnectionID;
-    unsigned long numFetchedInstructions;
+    int fetchingConnectionID;
 
   public:
     inline SimpleCore()
         : instructionMemory(NULL),
           dataMemory(NULL),
+          fetching(NULL),
           numFetchedInstructions(0) {}
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter,

--- a/src/std_components/engine_debug_component.hpp
+++ b/src/std_components/engine_debug_component.hpp
@@ -42,9 +42,11 @@
 class EngineDebugComponent
     : public sinuca::Component<sinuca::InstructionPacket> {
   private:
-    bool send;
-    int connectionID;
     EngineDebugComponent* other;
+    Component<sinuca::InstructionPacket>* fetch;
+    int otherConnectionID;
+    int fetchConnectionID;
+    bool send;
     bool shallFailOnFinish;
     /** @brief If >0, asks the engine for a flush at this cycle. */
     long flush;
@@ -55,9 +57,11 @@ class EngineDebugComponent
 
   public:
     inline EngineDebugComponent()
-        : send(false),
-          connectionID(-1),
-          other(NULL),
+        : other(NULL),
+          fetch(NULL),
+          otherConnectionID(-1),
+          fetchConnectionID(-1),
+          send(false),
           shallFailOnFinish(true),
           flush(-1) {}
 

--- a/src/utils/circular_buffer.cpp
+++ b/src/utils/circular_buffer.cpp
@@ -50,7 +50,7 @@ void CircularBuffer::Allocate(int bufferSize, int elementSize) {
 
 void CircularBuffer::Deallocate() {
     if (this->buffer) {
-        delete[] (char*)this->buffer;
+        free(this->buffer);
         this->buffer = NULL;
     }
 }

--- a/src/utils/circular_buffer.hpp
+++ b/src/utils/circular_buffer.hpp
@@ -66,7 +66,7 @@ class CircularBuffer {
     /**
      * @brief Returns a boolean indicating whether the Buffer is full.
      */
-    inline bool IsFull() { return this->occupation == this->maxBufferSize; };
+    inline bool IsFull() { return this->occupation == this->bufferSize; };
 
     /**
      * @brief Returns a boolean indicating whether the Buffer is empty.


### PR DESCRIPTION
This "inverts" the fetching API so the engine is a component.

Basically, instead of doing:

```yaml
core:
  class: SimpleCore

cores:
  - core
```

Now we do:

```yaml
instantiate:
  class: SimpleCore
  fetching: *ENGINE
```

The engine itself has a pre-defined alias and, instead of it "requesting" to
fetch to a core, the core requests an instruction to it. As this removes the
`cores` array, the `instantiate` parameter was added so there's a way of
instantiating an anonymous component.

This solves a lot of things, like the problems regarding branch predictors.
Also, it solves #60.
