### PR TITLE
Fixed sized connections with circular buffer

### DIFF
--- a/src/std_components/engine_debug_component.cpp
+++ b/src/std_components/engine_debug_component.cpp
@@ -156,6 +156,7 @@ void EngineDebugComponent::Clock() {
                 SINUCA3_DEBUG_PRINTF("%p: Received response (%p) from %p.\n",
                                      this, messageOutput.staticInfo,
                                      this->other);
+                this->send = false;
             } else {
                 SINUCA3_DEBUG_PRINTF("%p: No response from %p.\n", this,
                                      this->other);

--- a/src/utils/circular_buffer.cpp
+++ b/src/utils/circular_buffer.cpp
@@ -33,6 +33,7 @@ void CircularBuffer::Allocate(int bufferSize, int elementSize) {
     this->startOfBuffer = 0;
     this->endOfBuffer = 0;
     this->elementSize = elementSize;
+    this->bufferSize = bufferSize;
 
     this->maxBufferSize = bufferSize;
 


### PR DESCRIPTION
This time is for real (again).

The circular buffer wasn't initialized with it's own size when the connection
was sized.

Single-line fix.

I also added a line in the debugger component to more easily catch these ones
in the future.
