### PR TITLE
Fixed various engine bugs

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -64,6 +64,7 @@ void sinuca::engine::Engine::Fetch(int id, sinuca::FetchPacket packet) {
     }
 
     long weight = this->fetchBuffers[id].staticInfo->opcodeSize;
+
     while (weight < packet.request) {
         if (this->SendBufferedAndFetch(id)) {
             return;
@@ -117,6 +118,7 @@ int sinuca::engine::Engine::SetupSimulation(
             traceReader::FetchResultOk) {
             return 1;
         }
+        ++this->fetchedInstructions;
     }
 
     return 0;

--- a/src/engine/engine.hpp
+++ b/src/engine/engine.hpp
@@ -78,6 +78,7 @@ class Engine : public Component<FetchPacket> {
   public:
     inline Engine()
         : components(NULL),
+          fetchBuffers(NULL),
           numberOfComponents(0),
           numberOfFetchers(0),
           totalCycles(0),


### PR DESCRIPTION
This fixes various engine bugs introduced when I reverted the fetching API:
- No error message when instantiating a definition with an unknown class name;  
- Engine was calling the `delete` operator on itself on error;  
- Engine was not calling FinishSetup for components.  
