### PR TITLE
Made predictors reuse the instruction static info

### DIFF
--- a/src/engine/default_packets.hpp
+++ b/src/engine/default_packets.hpp
@@ -151,15 +151,15 @@ enum PredictorPacketType {
  */
 struct PredictorPacket {
     union {
-        StaticInstructionInfo* requestQuery;
+        const StaticInstructionInfo* requestQuery;
 
         struct {
-            StaticInstructionInfo* instruction;
+            const StaticInstructionInfo* instruction;
             unsigned long target;
         } requestUpdate;
 
         struct {
-            StaticInstructionInfo* instruction;
+            const StaticInstructionInfo* instruction;
             unsigned long target;
         } response;
     } data;

--- a/src/std_components/predictors/interleavedBTB.cpp
+++ b/src/std_components/predictors/interleavedBTB.cpp
@@ -61,7 +61,7 @@ int BTBEntry::Allocate(unsigned int numBanks) {
 
 int BTBEntry::NewEntry(unsigned long tag, unsigned int bank,
                        unsigned long target,
-                       sinuca::StaticInstructionInfo* instruction) {
+                       const sinuca::StaticInstructionInfo* instruction) {
     if (bank >= this->numBanks) return 1;
 
     this->entryTag = tag;
@@ -218,7 +218,7 @@ unsigned long BranchTargetBuffer::CalculateIndex(unsigned long address) {
 }
 
 int BranchTargetBuffer::RegisterNewBranch(
-    sinuca::StaticInstructionInfo* instruction, unsigned long target) {
+    const sinuca::StaticInstructionInfo* instruction, unsigned long target) {
     unsigned long index = this->CalculateIndex(instruction->opcodeAddress);
     unsigned long tag = this->CalculateTag(instruction->opcodeAddress);
     unsigned int bank = this->CalculateBank(instruction->opcodeAddress);
@@ -226,8 +226,8 @@ int BranchTargetBuffer::RegisterNewBranch(
     return this->btb[index]->NewEntry(tag, bank, target, instruction);
 }
 
-int BranchTargetBuffer::UpdateBranch(sinuca::StaticInstructionInfo* instruction,
-                                     bool branchState) {
+int BranchTargetBuffer::UpdateBranch(
+    const sinuca::StaticInstructionInfo* instruction, bool branchState) {
     unsigned long index = this->CalculateIndex(instruction->opcodeAddress);
     unsigned int bank = this->CalculateBank(instruction->opcodeAddress);
 
@@ -235,7 +235,7 @@ int BranchTargetBuffer::UpdateBranch(sinuca::StaticInstructionInfo* instruction,
 }
 
 inline void BranchTargetBuffer::Query(
-    sinuca::StaticInstructionInfo* instruction, int connectionID) {
+    const sinuca::StaticInstructionInfo* instruction, int connectionID) {
     unsigned long index = this->CalculateIndex(instruction->opcodeAddress);
     unsigned long tag = this->CalculateTag(instruction->opcodeAddress);
     BTBPacket response;
@@ -293,12 +293,13 @@ inline void BranchTargetBuffer::Query(
 }
 
 inline int BranchTargetBuffer::AddEntry(
-    sinuca::StaticInstructionInfo* instruction, unsigned long targetAddress) {
+    const sinuca::StaticInstructionInfo* instruction,
+    unsigned long targetAddress) {
     return this->RegisterNewBranch(instruction, targetAddress);
 }
 
 inline int BranchTargetBuffer::Update(
-    sinuca::StaticInstructionInfo* instruction, bool branchState) {
+    const sinuca::StaticInstructionInfo* instruction, bool branchState) {
     return this->UpdateBranch(instruction, branchState);
 }
 

--- a/src/std_components/predictors/interleavedBTB.hpp
+++ b/src/std_components/predictors/interleavedBTB.hpp
@@ -66,24 +66,24 @@ enum BTBPacketType {
 
 struct BTBPacket {
     union {
-        sinuca::StaticInstructionInfo*
+        const sinuca::StaticInstructionInfo*
             requestQuery; /**<Instruction info to query about.>*/
 
         struct {
-            sinuca::StaticInstructionInfo*
+            const sinuca::StaticInstructionInfo*
                 instruction;  /**<Instruction info this response is about.>*/
             bool branchState; /**<The result of the branch, whether it was taken
                                  or not. */
         } requestUpdate;
 
         struct {
-            sinuca::StaticInstructionInfo*
+            const sinuca::StaticInstructionInfo*
                 instruction;      /**<Instruction info to add.>*/
             unsigned long target; /**<The branch's jump address. */
         } requestAddEntry;
 
         struct {
-            sinuca::StaticInstructionInfo*
+            const sinuca::StaticInstructionInfo*
                 instruction; /**<Instruction info this response is about.>*/
             unsigned int numberOfBits; /**<Size of valid bits array. */
             unsigned long target;      /**<The target address for the next
@@ -124,7 +124,7 @@ struct BTBEntry {
      * @return 0 if successfuly, 1 otherwise.
      */
     int NewEntry(unsigned long tag, unsigned int bank, unsigned long target,
-                 sinuca::StaticInstructionInfo* instruction);
+                 const sinuca::StaticInstructionInfo* instruction);
 
     /**
      * @brief Update the BTB entry.
@@ -221,7 +221,7 @@ class BranchTargetBuffer : public sinuca::Component<struct BTBPacket> {
      * @param type The type of branch.
      * @return 0 if successfuly, 1 otherwise.
      */
-    int RegisterNewBranch(sinuca::StaticInstructionInfo* instruction,
+    int RegisterNewBranch(const sinuca::StaticInstructionInfo* instruction,
                           unsigned long targetAddress);
 
     /**
@@ -231,7 +231,7 @@ class BranchTargetBuffer : public sinuca::Component<struct BTBPacket> {
      * or not.
      * @return 0 if successfuly, 1 otherwise.
      */
-    int UpdateBranch(sinuca::StaticInstructionInfo* instruction,
+    int UpdateBranch(const sinuca::StaticInstructionInfo* instruction,
                      bool branchState);
 
     /**
@@ -248,7 +248,7 @@ class BranchTargetBuffer : public sinuca::Component<struct BTBPacket> {
      * limited vector with all bits set to 1, assuming that all instructions in
      * the block are predicted to execute.
      */
-    inline void Query(sinuca::StaticInstructionInfo* instruction,
+    inline void Query(const sinuca::StaticInstructionInfo* instruction,
                       int connectionID);
 
     /**
@@ -257,7 +257,7 @@ class BranchTargetBuffer : public sinuca::Component<struct BTBPacket> {
      * @param targetAddress The target address of the branch instruction.
      * @details A wrapper for the method of registering a new entry in the BTB.
      */
-    inline int AddEntry(sinuca::StaticInstructionInfo* instruction,
+    inline int AddEntry(const sinuca::StaticInstructionInfo* instruction,
                         unsigned long targetAddress);
 
     /**
@@ -266,7 +266,7 @@ class BranchTargetBuffer : public sinuca::Component<struct BTBPacket> {
      * @param branchState The Information on whether the branch has been taken.
      * @details A wrapper for the method of updating an entry in the BTB.
      */
-    inline int Update(sinuca::StaticInstructionInfo* instruction,
+    inline int Update(const sinuca::StaticInstructionInfo* instruction,
                       bool branchState);
 
   public:

--- a/src/std_components/predictors/ras.cpp
+++ b/src/std_components/predictors/ras.cpp
@@ -82,7 +82,7 @@ int Ras::SetConfigParameter(const char* parameter,
     return 1;
 }
 
-inline void Ras::RequestQuery(sinuca::StaticInstructionInfo* instruction,
+inline void Ras::RequestQuery(const sinuca::StaticInstructionInfo* instruction,
                               int connectionID) {
     unsigned long prediction = this->buffer[this->end];
     --this->end;

--- a/src/std_components/predictors/ras.hpp
+++ b/src/std_components/predictors/ras.hpp
@@ -42,7 +42,7 @@ class Ras : public sinuca::Component<sinuca::PredictorPacket> {
 
     int forwardToID;
 
-    inline void RequestQuery(sinuca::StaticInstructionInfo* instruction,
+    inline void RequestQuery(const sinuca::StaticInstructionInfo* instruction,
                              int connectionID);
 
     inline void RequestUpdate(unsigned long targetAddress);


### PR DESCRIPTION
This makes predictors use the static instruction info pointer so their clients
don't need to parse them regarding branch types, and the branch types are
standardized.

The ras works, I cannot be sure about the BTB.
