### PR TITLE
Removed flush API

### DIFF
--- a/config_files/engine_debug.yaml
+++ b/config_files/engine_debug.yaml
@@ -1,6 +1,5 @@
 example: &example
   class: EngineDebugComponent
-  flush: 15
   pointer:
     class: EngineDebugComponent
     pointerOther: *otherComponent

--- a/src/custom_components/custom_example.cpp
+++ b/src/custom_components/custom_example.cpp
@@ -34,8 +34,6 @@ int CustomExample::SetConfigParameter(const char* parameter,
 
 void CustomExample::Clock() {}
 
-void CustomExample::Flush() {}
-
 int CustomExample::FinishSetup() { return 0; }
 
 void CustomExample::PrintStatistics() {}

--- a/src/custom_components/custom_example.hpp
+++ b/src/custom_components/custom_example.hpp
@@ -53,12 +53,6 @@ class CustomExample : public Component<int> {
      * @returns Non-zero on error, 0 otherwise.
      */
     virtual int SetConfigParameter(const char* parameter, ConfigValue value);
-    /**
-     * @brief This method is called by the engine when a flush should occur.
-     * It's always called at the beggining of the cycle. Components can request
-     * a flush calling sinuca::ENGINE->flush().
-     */
-    virtual void Flush();
 
     /**
      * @brief This method is called at the end of the simulation for each

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -88,8 +88,6 @@ void Engine::Clock() {
     }
 }
 
-void Engine::Flush() { this->flush = true; }
-
 void Engine::PrintStatistics() {
     SINUCA3_LOG_PRINTF("engine: Cycled %lu times.\n", this->totalCycles);
     SINUCA3_LOG_PRINTF("engine: Fetched %lu instructions.\n",
@@ -141,14 +139,6 @@ int Engine::Simulate(TraceReader* traceReader) {
     while (!this->end && !this->error) {
         if ((this->totalCycles + 1) % (1 << 8) == 0)
             this->PrintTime(start, this->totalCycles + 1);
-
-        if (this->flush) {
-            for (long i = 0; i < this->numberOfComponents; ++i) {
-                this->components[i]->Flush();
-                this->components[i]->LinkableFlush();
-            }
-            this->flush = false;
-        }
 
         for (long i = 0; i < this->numberOfComponents; ++i)
             this->components[i]->Clock();

--- a/src/engine/engine.hpp
+++ b/src/engine/engine.hpp
@@ -49,11 +49,6 @@ class Engine : public Component<FetchPacket> {
         fetchedInstructions; /** @brief Counter of instructions fetched. */
 
     /**
-     * @brief This variable tells wether a flush should occur in the beggining
-     * of the next clock.
-     */
-    bool flush;
-    /**
      * @brief Will be one when there's no more instructions in the trace file.
      */
     bool end;
@@ -82,7 +77,6 @@ class Engine : public Component<FetchPacket> {
           numberOfFetchers(0),
           totalCycles(0),
           fetchedInstructions(0),
-          flush(false),
           end(false),
           error(false) {}
 
@@ -102,7 +96,6 @@ class Engine : public Component<FetchPacket> {
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter, ConfigValue value);
     virtual void Clock();
-    virtual void Flush();
     virtual void PrintStatistics();
 
     virtual ~Engine();

--- a/src/engine/linkable.cpp
+++ b/src/engine/linkable.cpp
@@ -62,13 +62,6 @@ void Connection::SwapBuffers() {
     this->responseBuffers[1] = aux;
 }
 
-void Connection::FlushConnection() {
-    this->requestBuffers[0]->Flush();
-    this->requestBuffers[1]->Flush();
-    this->responseBuffers[0]->Flush();
-    this->responseBuffers[1]->Flush();
-}
-
 bool Connection::InsertIntoRequestBuffer(int id, void* messageInput) {
     return this->requestBuffers[id]->Enqueue(messageInput);
 }
@@ -108,11 +101,6 @@ void Linkable::AddConnection(Connection* newConnection) {
 }
 
 long Linkable::GetNumberOfConnections() { return this->numberOfConnections; }
-
-void Linkable::LinkableFlush() {
-    for (unsigned int i = 0; i < this->connections.size(); ++i)
-        this->connections[i]->FlushConnection();
-}
 
 void Linkable::PosClock() {
     for (unsigned int i = 0; i < this->connections.size(); ++i)

--- a/src/engine/linkable.hpp
+++ b/src/engine/linkable.hpp
@@ -69,12 +69,6 @@ struct Connection {
     void SwapBuffers();
 
     /**
-     * @brief Flush the connection, clearing the buffers.
-     * @details This method is called to clear the buffers of the connection.
-     */
-    void FlushConnection();
-
-    /**
      * @brief Insert a message into a requestBuffer.
      * @param id The id of the buffer.
      * @param messageInput A pointer to the message to send.
@@ -218,11 +212,6 @@ class Linkable {
      */
     void PosClock();
     /**
-     * @brief Don't call this method.
-     * @details The engine calls this method when a flush is needed.
-     */
-    void LinkableFlush();
-    /**
      * @brief This method should be declared here so the simulator can send the
      * finish setup message.
      * @details This method is called after the config file is and all
@@ -251,12 +240,6 @@ class Linkable {
      * clock cycles.
      */
     virtual void Clock() = 0;
-
-    /**
-     * @brief This method is called by the engine when a flush should occur.
-     * It's always called at the beggining of the cycle.
-     */
-    virtual void Flush() = 0;
 
     /**
      * @brief This method is called by the engine after the simulation stops, so

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,9 +35,6 @@
 #include <tests.hpp>
 #endif
 
-/** @brief Definition of the ENGINE global object declared in sinuca3.hpp. */
-Engine* ENGINE;
-
 /**
  * @brief Prints licensing information.
  */
@@ -164,8 +161,8 @@ int main(int argc, char* const argv[]) {
     }
 
     EngineBuilder builder;
-    ENGINE = builder.Instantiate(rootConfigFile);
-    if (ENGINE == NULL) return 1;
+    Engine* engine = builder.Instantiate(rootConfigFile);
+    if (engine == NULL) return 1;
 
     TraceReader* traceReader = AllocTraceReader(traceReaderName);
     if (traceReader == NULL) {
@@ -175,8 +172,8 @@ int main(int argc, char* const argv[]) {
     }
     if (traceReader->OpenTrace(traceFileName, traceDir)) return 1;
 
-    ENGINE->Simulate(traceReader);
-    delete ENGINE;
+    engine->Simulate(traceReader);
+    delete engine;
     delete traceReader;
 
     return 0;

--- a/src/sinuca3.hpp
+++ b/src/sinuca3.hpp
@@ -32,11 +32,6 @@
 #include <engine/linkable.hpp>
 #include <utils/logging.hpp>  // IWYU pragma: export
 
-/**
- * @brief Global engine object so everyone can call it's methods.
- */
-extern Engine* ENGINE;
-
 #define COMPONENT(type) \
     if (!strcmp(name, #type)) return new type
 

--- a/src/std_components/cores/simple_core.cpp
+++ b/src/std_components/cores/simple_core.cpp
@@ -126,8 +126,6 @@ void SimpleCore::Clock() {
     }
 }
 
-void SimpleCore::Flush() {}
-
 void SimpleCore::PrintStatistics() {
     SINUCA3_LOG_PRINTF("SimpleCore %p: %lu instructions fetched\n", this,
                        this->numFetchedInstructions);

--- a/src/std_components/cores/simple_core.hpp
+++ b/src/std_components/cores/simple_core.hpp
@@ -56,7 +56,6 @@ class SimpleCore : public Component<InstructionPacket> {
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter, ConfigValue value);
     virtual void Clock();
-    virtual void Flush();
     virtual void PrintStatistics();
     ~SimpleCore();
 };

--- a/src/std_components/engine_debug_component.cpp
+++ b/src/std_components/engine_debug_component.cpp
@@ -93,10 +93,6 @@ int EngineDebugComponent::SetConfigParameter(const char* parameter,
         this->otherConnectionID = this->other->Connect(4);
         return 0;
     }
-    if (strcmp(parameter, "flush") == 0) {
-        this->flush = value.value.integer;
-        return 0;
-    }
     if (strcmp(parameter, "fetch") == 0) {
         this->fetch = dynamic_cast<Component<FetchPacket>*>(
             value.value.componentReference);
@@ -133,11 +129,6 @@ void EngineDebugComponent::Clock() {
         }
     }
 
-    if (this->flush > 0) {
-        --this->flush;
-        if (this->flush == 0) ENGINE->Flush();
-    }
-
     InstructionPacket messageInput = {NULL, DynamicInstructionInfo(), 0};
     InstructionPacket messageOutput = {NULL, DynamicInstructionInfo(), 0};
 
@@ -172,10 +163,6 @@ void EngineDebugComponent::Clock() {
             }
         }
     }
-}
-
-void EngineDebugComponent::Flush() {
-    SINUCA3_DEBUG_PRINTF("%p: A flush happened!\n", this);
 }
 
 void EngineDebugComponent::PrintStatistics() {

--- a/src/std_components/engine_debug_component.hpp
+++ b/src/std_components/engine_debug_component.hpp
@@ -33,11 +33,7 @@
  * @details The component will log with SINUCA3_DEBUG_PRINTF it's parameters
  * along with their values. If passed the parameter "failNow" with any value,
  * the method SetConfigParameter will return with failure. If passed the
- * parameter "failOnFinish", the method FinishSetup will return with failure. If
- * passed the parameter "flush" with an integer n, it'll ask the engine to flush
- * after n cycles. It'll also log it's clock. Before each log, the pointer to
- * the component is printed to differentiate between multiple
- * EngineDebugComponent.
+ * parameter "failOnFinish", the method FinishSetup will return with failure.
  */
 class EngineDebugComponent : public Component<InstructionPacket> {
   private:
@@ -50,7 +46,6 @@ class EngineDebugComponent : public Component<InstructionPacket> {
     bool send; /** @brief Tells wether we already sent a message to other. */
     bool shallFailOnFinish; /** @brief If true, fails at the FinishSetup method
                                to test the engine handling of failures. */
-    long flush; /** @brief If >0, asks the engine for a flush at this cycle. */
 
     /**
      * @brief Prints a config value along with the parameter name. This is
@@ -70,13 +65,11 @@ class EngineDebugComponent : public Component<InstructionPacket> {
           otherConnectionID(-1),
           fetchConnectionID(-1),
           send(false),
-          shallFailOnFinish(false),
-          flush(-1) {}
+          shallFailOnFinish(false) {}
 
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter, ConfigValue value);
     virtual void Clock();
-    virtual void Flush();
     virtual void PrintStatistics();
 
     virtual ~EngineDebugComponent();

--- a/src/std_components/execute/simple_execution_unit.cpp
+++ b/src/std_components/execute/simple_execution_unit.cpp
@@ -34,8 +34,6 @@ int SimpleExecutionUnit::SetConfigParameter(const char* parameter,
 
 int SimpleExecutionUnit::FinishSetup() { return 0; }
 
-void SimpleExecutionUnit::Flush() {}
-
 void SimpleExecutionUnit::Clock() {
     unsigned long numberOfConnections = this->GetNumberOfConnections();
     for (unsigned long i = 0; i < numberOfConnections; ++i) {

--- a/src/std_components/execute/simple_execution_unit.hpp
+++ b/src/std_components/execute/simple_execution_unit.hpp
@@ -40,7 +40,6 @@ class SimpleExecutionUnit : public Component<InstructionPacket> {
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter, ConfigValue value);
     virtual void Clock();
-    virtual void Flush();
     virtual void PrintStatistics();
     ~SimpleExecutionUnit();
 };

--- a/src/std_components/fetch/fetcher.cpp
+++ b/src/std_components/fetch/fetcher.cpp
@@ -285,8 +285,6 @@ void Fetcher::Clock() {
     ++this->fetchClock;
 }
 
-void Fetcher::Flush() {}
-
 void Fetcher::PrintStatistics() {
     SINUCA3_LOG_PRINTF("Fetcher %p: %lu fetched instructions.\n", this,
                        this->fetchedInstructions);

--- a/src/std_components/fetch/fetcher.hpp
+++ b/src/std_components/fetch/fetcher.hpp
@@ -142,7 +142,6 @@ class Fetcher : public Component<int> {
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter, ConfigValue value);
     virtual void Clock();
-    virtual void Flush();
     virtual void PrintStatistics();
 
     virtual ~Fetcher();

--- a/src/std_components/fetch/queue.cpp
+++ b/src/std_components/fetch/queue.cpp
@@ -41,7 +41,6 @@ class QueueTester : public Component<long> {
         return 0;
     }
     virtual void Clock() {}
-    virtual void Flush() {}
     virtual void PrintStatistics() {}
     virtual ~QueueTester() {}
 

--- a/src/std_components/fetch/queue.hpp
+++ b/src/std_components/fetch/queue.hpp
@@ -58,7 +58,6 @@ class Queue : public Component<Type> {
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter, ConfigValue value);
     virtual void Clock();
-    virtual void Flush();
     virtual void PrintStatistics();
     virtual ~Queue();
 };
@@ -120,9 +119,6 @@ void Queue<Type>::Clock() {
         }
     }
 }
-
-template <typename Type>
-void Queue<Type>::Flush() {}
 
 template <typename Type>
 void Queue<Type>::PrintStatistics() {}

--- a/src/std_components/memory/simple_instruction_memory.cpp
+++ b/src/std_components/memory/simple_instruction_memory.cpp
@@ -66,8 +66,6 @@ void SimpleInstructionMemory::Clock() {
     }
 }
 
-void SimpleInstructionMemory::Flush() {}
-
 void SimpleInstructionMemory::PrintStatistics() {
     SINUCA3_LOG_PRINTF("SimpleInstructionMemory %p: %lu requests made\n", this,
                        this->numberOfRequests);

--- a/src/std_components/memory/simple_instruction_memory.hpp
+++ b/src/std_components/memory/simple_instruction_memory.hpp
@@ -49,7 +49,6 @@ class SimpleInstructionMemory : public Component<InstructionPacket> {
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter, ConfigValue value);
     virtual void Clock();
-    virtual void Flush();
     virtual void PrintStatistics();
     ~SimpleInstructionMemory();
 };

--- a/src/std_components/memory/simple_memory.cpp
+++ b/src/std_components/memory/simple_memory.cpp
@@ -44,8 +44,6 @@ void SimpleMemory::Clock() {
     }
 }
 
-void SimpleMemory::Flush() {}
-
 void SimpleMemory::PrintStatistics() {
     SINUCA3_LOG_PRINTF("SimpleMemory %p: %lu requests made\n", this,
                        this->numberOfRequests);

--- a/src/std_components/memory/simple_memory.hpp
+++ b/src/std_components/memory/simple_memory.hpp
@@ -41,7 +41,6 @@ class SimpleMemory : public Component<MemoryPacket> {
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter, ConfigValue value);
     virtual void Clock();
-    virtual void Flush();
     virtual void PrintStatistics();
     ~SimpleMemory();
 };

--- a/src/std_components/predictors/hardwired_predictor.cpp
+++ b/src/std_components/predictors/hardwired_predictor.cpp
@@ -139,8 +139,6 @@ void HardwiredPredictor::Clock() {
     }
 }
 
-void HardwiredPredictor::Flush() {}
-
 void HardwiredPredictor::PrintStatistics() {
     SINUCA3_LOG_PRINTF(
         "HardwiredPredictor %p: %lu syscalls executed (predict: %b).\n", this,

--- a/src/std_components/predictors/hardwired_predictor.hpp
+++ b/src/std_components/predictors/hardwired_predictor.hpp
@@ -95,7 +95,6 @@ class HardwiredPredictor : public Component<PredictorPacket> {
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter, ConfigValue value);
     virtual void Clock();
-    virtual void Flush();
     virtual void PrintStatistics();
 
     virtual ~HardwiredPredictor();

--- a/src/std_components/predictors/interleavedBTB.cpp
+++ b/src/std_components/predictors/interleavedBTB.cpp
@@ -333,8 +333,6 @@ void BranchTargetBuffer::Clock() {
     }
 }
 
-void BranchTargetBuffer::Flush() {};
-
 void BranchTargetBuffer::PrintStatistics() {
     SINUCA3_LOG_PRINTF("BranchTargetBuffer %p: %lu queries", this,
                        this->numQueries);

--- a/src/std_components/predictors/interleavedBTB.hpp
+++ b/src/std_components/predictors/interleavedBTB.hpp
@@ -276,8 +276,6 @@ class BranchTargetBuffer : public Component<struct BTBPacket> {
 
     virtual void Clock();
 
-    virtual void Flush();
-
     virtual void PrintStatistics();
 
     ~BranchTargetBuffer();

--- a/src/std_components/predictors/ras.cpp
+++ b/src/std_components/predictors/ras.cpp
@@ -127,8 +127,6 @@ void Ras::Clock() {
     }
 }
 
-void Ras::Flush() {}
-
 void Ras::PrintStatistics() {
     SINUCA3_LOG_PRINTF("Ras %p: %lu queries\n", this, this->numQueries);
     SINUCA3_LOG_PRINTF("Ras %p: %lu updates\n", this, this->numUpdates);

--- a/src/std_components/predictors/ras.hpp
+++ b/src/std_components/predictors/ras.hpp
@@ -57,7 +57,6 @@ class Ras : public Component<PredictorPacket> {
     virtual int FinishSetup();
     virtual int SetConfigParameter(const char* parameter, ConfigValue value);
     virtual void Clock();
-    virtual void Flush();
     virtual void PrintStatistics();
 
     virtual ~Ras();

--- a/src/utils/circular_buffer.cpp
+++ b/src/utils/circular_buffer.cpp
@@ -126,9 +126,3 @@ bool CircularBuffer::Dequeue(void* elementOutput) {
 
     return 1;
 }
-
-void CircularBuffer::Flush() {
-    this->occupation = 0;
-    this->startOfBuffer = 0;
-    this->endOfBuffer = 0;
-}

--- a/src/utils/circular_buffer.hpp
+++ b/src/utils/circular_buffer.hpp
@@ -109,12 +109,6 @@ class CircularBuffer {
      */
     bool Dequeue(void* elementOutput);
 
-    /**
-     * @brief Flushes the buffer.
-     * @details This method is called to clear the buffer.
-     */
-    void Flush();
-
     ~CircularBuffer() { this->Deallocate(); };
 };
 


### PR DESCRIPTION
This removes the flushing API as it was deemed useless, as simulating the wrong path is basically impossible with our architecture. The only component that was actually flush-aware was the EngineDebugComponent itself.