### PR TITLE
Fixed wrong impossible comparison causing a malloc corruption

### DIFF
--- a/src/config/engine_builder.cpp
+++ b/src/config/engine_builder.cpp
@@ -236,7 +236,7 @@ int EngineBuilder::FillParametersAndClass(
 
         // If we're on the last item and class was not provided, appending would
         // overflow, but we know that class was not provided!
-        if (i == config->size() && definition->clazz == NULL) {
+        if (i == config->size() - 1 && definition->clazz == NULL) {
             SINUCA3_ERROR_PRINTF(
                 "While trying to define component %s: parameter `class` was "
                 "not provided.\n",


### PR DESCRIPTION
This fixes a wrong comparison causing a malloc corruption under some circunstances on the configuration code. It also made so the simulator would try to start with some components without a defined class.