### PR TITLE
Fixed Pin compilation for gcc 16.1.1.

### DIFF
--- a/x86_trace_generator/pin/source/tools/Config/makefile.unix.config
+++ b/x86_trace_generator/pin/source/tools/Config/makefile.unix.config
@@ -121,7 +121,7 @@ endif
 # the end of this file, same as APP_CXXFLAGS.
 
 APP_CXXFLAGS_NOOPT :=
-TOOL_CXXFLAGS_NOOPT := -Wall -Werror -Wno-unknown-pragmas -DPIN_CRT=1
+TOOL_CXXFLAGS_NOOPT := -Wall -Wno-unknown-pragmas -DPIN_CRT=1
 DLL_CXXFLAGS :=
 ENABLE_DEPRECATED := -DPIN_DEPRECATED_WARNINGS=0
 CPP11FLAGS := -std=c++11


### PR DESCRIPTION
Pin used to use -Werror. As of gcc 16.1.1, new warnings cause the compilation to
fail. This simply removes the -Werror flag so we can compile Pin with newer gcc
versions.